### PR TITLE
Correct mistake when detecting candidate letters

### DIFF
--- a/TextDetection.cpp
+++ b/TextDetection.cpp
@@ -525,21 +525,21 @@ findLegallyConnectedComponents (IplImage * SWTImage,
                     int this_pixel = map[row * SWTImage->width + col];
                     if (col+1 < SWTImage->width) {
                         float right = CV_IMAGE_ELEM(SWTImage, float, row, col+1);
-                        if (right > 0 && ((*ptr)/right <= 3.0 || right/(*ptr) <= 3.0))
+                        if (right > 0 && ((*ptr)/right <= 3.0 && right/(*ptr) <= 3.0))
                             boost::add_edge(this_pixel, map.at(row * SWTImage->width + col + 1), g);
                     }
                     if (row+1 < SWTImage->height) {
                         if (col+1 < SWTImage->width) {
                             float right_down = CV_IMAGE_ELEM(SWTImage, float, row+1, col+1);
-                            if (right_down > 0 && ((*ptr)/right_down <= 3.0 || right_down/(*ptr) <= 3.0))
+                            if (right_down > 0 && ((*ptr)/right_down <= 3.0 && right_down/(*ptr) <= 3.0))
                                 boost::add_edge(this_pixel, map.at((row+1) * SWTImage->width + col + 1), g);
                         }
                         float down = CV_IMAGE_ELEM(SWTImage, float, row+1, col);
-                        if (down > 0 && ((*ptr)/down <= 3.0 || down/(*ptr) <= 3.0))
+                        if (down > 0 && ((*ptr)/down <= 3.0 && down/(*ptr) <= 3.0))
                             boost::add_edge(this_pixel, map.at((row+1) * SWTImage->width + col), g);
                         if (col-1 >= 0) {
                             float left_down = CV_IMAGE_ELEM(SWTImage, float, row+1, col-1);
-                            if (left_down > 0 && ((*ptr)/left_down <= 3.0 || left_down/(*ptr) <= 3.0))
+                            if (left_down > 0 && ((*ptr)/left_down <= 3.0 && left_down/(*ptr) <= 3.0))
                                 boost::add_edge(this_pixel, map.at((row+1) * SWTImage->width + col - 1), g);
                         }
                     }
@@ -602,7 +602,7 @@ findLegallyConnectedComponentsRAY (IplImage * SWTImage,
                 for (std::vector<Point2d>::const_iterator it2 = it->points.begin(); it2 != it->points.end(); it2++) {
                         float currentSW = CV_IMAGE_ELEM(SWTImage, float, it2->y, it2->x);
                         if (lastSW == 0) {}
-                        else if (lastSW/currentSW<=3.0 || currentSW/lastSW<=3.0){
+                        else if (lastSW/currentSW<=3.0 && currentSW/lastSW<=3.0){
                                 boost::add_edge(map.at(it2->y * SWTImage->width + it2->x), map.at(lastRow * SWTImage->width + lastCol), g);
                         }
                         lastSW = currentSW;


### PR DESCRIPTION
I have made some adjustments to the findlegallyconnectedcomponents(rays). The if conditions when looking to the ratios should be && instead of || operators. Since you will always have a true value with ||, which is not the purpose of that statement. Now the ratio should be bounded to 3.0 like described in the algorithm.